### PR TITLE
Refactor the returned forecast into class objects

### DIFF
--- a/pojos/currently.js
+++ b/pojos/currently.js
@@ -1,0 +1,20 @@
+class Currently {
+
+  constructor(data) {
+    this.summary = data.currently.summary;
+    this.icon = data.currently.icon;
+    this.precipIntensity = data.currently.precipIntensity;
+    this.precipProbability = data.currently.precipProbability;
+    this.temperature = data.currently.temperature;
+    this.humidity = data.currently.humidity;
+    this.pressure = data.currently.pressure;
+    this.windSpeed = data.currently.windSpeed;
+    this.windGust = data.currently.windGust;
+    this.windBearing = data.currently.windBearing;
+    this.cloudCover = data.currently.cloudCover;
+    this.visibility = data.currently.visibility;
+  }
+
+}
+
+module.exports = Currently;

--- a/pojos/daily.js
+++ b/pojos/daily.js
@@ -1,0 +1,22 @@
+let DailyForecast = require("./daily_forecast");
+
+class Daily {
+  constructor(data) {
+    this.summary = data.daily.summary;
+    this.icon = data.daily.icon;
+    this.data = this.dailyForecast(data);
+  }
+
+  dailyForecast(data) {
+    let sevenDaysOfForecastData = data.daily.data.slice(0, 7);
+
+    let forecastArray = [];
+    let x = sevenDaysOfForecastData.forEach(function (item, index) {
+      let forecast = new DailyForecast(item);
+      forecastArray.push(forecast);
+    });
+    return forecastArray;
+  }
+}
+
+module.exports = Daily;

--- a/pojos/daily_forecast.js
+++ b/pojos/daily_forecast.js
@@ -1,0 +1,28 @@
+class DailyForecast {
+
+  constructor(data) {
+    this.time = data.time;
+    this.summary = data.summary;
+    this.icon = data.icon;
+    this.sunriseTime = data.sunriseTime;
+    this.sunsetTime = data.sunsetTime;
+    this.percipIntensity = data.percipIntensity;
+    this.percipIntensityMax = data.percipIntensityMax;
+    this.percipIntensityMaxTime = data.percipIntensityMaxTime;
+    this.precipProbability = data.precipProbability;
+    this.precipType = data.precipType;
+    this.temperatureHigh = data.temperatureHigh;
+    this.temperatureLow = data.temperatureLow;
+    this.humidity = data.humidity;
+    this.pressure = data.pressure;
+    this.windSpeed = data.windSpeed;
+    this.windGust = data.windGust;
+    this.cloudCover = data.cloudCover;
+    this.visibility = data.visibility;
+    this.temperatureMin = data.temperatureMin;
+    this.temperatureMax = data.temperatureMax;
+  }
+
+}
+
+module.exports = DailyForecast;

--- a/pojos/forecast.js
+++ b/pojos/forecast.js
@@ -1,0 +1,16 @@
+const Currently = require('./currently');
+const Hourly = require('./hourly');
+const Daily = require('./daily');
+
+class Forecast {
+
+  constructor(location, data) {
+    this.location = location;
+    this.currently = new Currently(data);
+    this.hourly = new Hourly(data);
+    this.daily = new Daily(data);
+  }
+
+}
+
+module.exports = Forecast;

--- a/pojos/hourly.js
+++ b/pojos/hourly.js
@@ -1,0 +1,23 @@
+let HourlyForecast = require("./hourly_forecast");
+
+class Hourly {
+
+  constructor(data) {
+    this.summary = data.hourly.summary;
+    this.icon = data.hourly.icon;
+    this.data = this.hourlyForecast(data);
+  }
+
+  hourlyForecast(data) {
+    let eightHoursOfForecastData = data.hourly.data.slice(0, 8);
+
+    let forecastArray = [];
+    let x = eightHoursOfForecastData.forEach(function (item, index) {
+      let forecast = new HourlyForecast(item);
+      forecastArray.push(forecast);
+    });
+    return forecastArray;
+  }
+}
+
+module.exports = Hourly;

--- a/pojos/hourly_forecast.js
+++ b/pojos/hourly_forecast.js
@@ -1,0 +1,21 @@
+class HourlyForecast {
+
+  constructor(data) {
+    this.time = data.time;
+    this.summary = data.summary;
+    this.icon = data.icon;
+    this.percipIntensity = data.percipIntensity;
+    this.precipProbability = data.precipProbability;
+    this.temperature = data.temperature;
+    this.humidity = data.humidity;
+    this.pressure = data.pressure;
+    this.windSpeed = data.windSpeed;
+    this.windGust = data.windGust;
+    this.windBearing = data.windBearing;
+    this.cloudCover = data.cloudCover;
+    this.visibility = data.visibility;
+  }
+
+}
+
+module.exports = HourlyForecast;

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -1,5 +1,5 @@
 const dotenv = require('dotenv').config();
-// let googleService = require("../../../services/google_service");
+const Forecast = require('../../../pojos/forecast');
 
 var express = require('express');
 var router = express.Router();
@@ -10,8 +10,9 @@ const database = require('knex')(configuration);
 const fetch = require('node-fetch');
 
 router.get('/', (request, response) => {
+  // CHECK THAT AN API KEY AND LOCATION WERE SENT WITH THE REQUEST
   if ((request.body.api_key) && (request.query.location)){
-
+    // QUERY THE DATABASE TO CHECK FOR A USER WITH THE PASSED IN API KEY
     database('users').where('api_key', request.body.api_key).first()
       .then((user) => {
 
@@ -40,66 +41,8 @@ router.get('/', (request, response) => {
                return response.json();
             })
             .then((json) => {
-
-              //
-
-              // CURRENT WEATHER INFO
-              let currentWeather = json.currently;
-              // CLEAN UP THE CURRENT WEATHER INFO
-              delete currentWeather.time;
-              delete currentWeather.nearestStormDistance;
-              delete currentWeather.nearestStormBearing;
-              delete currentWeather.apparentTemperature;
-              delete currentWeather.dewPoint;
-              delete currentWeather.uvIndex;
-              delete currentWeather.ozone;
-
-              // HOURLY WEATHER INFO
-              let hourlyWeather = json.hourly;
-              let hourlyWeatherSumamry = json.hourly.summary;
-              let hourlyWeatherIcon = json.hourly.icon;
-              let eightHourForecast = hourlyWeather.data.slice(0, 8);
-              // CLEAN UP THE EIGHT HOUR FORECAST INFO
-              eightHourForecast.forEach((day, index) => {
-                delete day.precipType;
-                delete day.precipAccumulation;
-                delete day.apparentTemperature;
-                delete day.dewPoint;
-                delete day.uvIndex;
-                delete day.ozone;
-                return eightHourForecast;
-              });
-
-              // DAILY WEATHER INFO
-              let dailyWeather = json.daily;
-              let dailyWeatherSumamry = json.daily.summary;
-              let dailyWeatherIcon = json.daily.icon;
-              let sevenDayForecast = dailyWeather.data.slice(0, 7);
-              // CLEAN UP THE SEVEN DAY FORECAST WEATHER INFO
-              sevenDayForecast.forEach((day, index) => {
-                delete day.moonPhase;
-                delete day.precipAccumulation;
-                delete day.temperatureHighTime;
-                delete day.temperatureLowTime;
-                delete day.apparentTemperatureHigh;
-                delete day.apparentTemperatureHighTime;
-                delete day.apparentTemperatureLow;
-                delete day.apparentTemperatureLowTime;
-                delete day.dewPoint;
-                delete day.windGustTime;
-                delete day.windBearing;
-                delete day.uvIndex;
-                delete day.uvIndexTime;
-                delete day.ozone;
-                delete day.temperatureMinTime;
-                delete day.temperatureMaxTime;
-                delete day.apparentTemperatureMin;
-                delete day.apparentTemperatureMinTime;
-                delete day.apparentTemperatureMax;
-                delete day.apparentTemperatureMaxTime;
-                return sevenDayForecast;
-              });
-              response.status(200).json({currently: currentWeather, hourly: {summary: hourlyWeatherSumamry, icon: hourlyWeatherIcon, data: eightHourForecast}, daily: {summary: dailyWeatherSumamry, icon: dailyWeatherIcon, data: sevenDayForecast}});
+              // // RETURN CURRENT WEATHER INFO
+              response.status(200).json(new Forecast(location, json));
             });
           // END OF DARSKY API FETCHING
         });


### PR DESCRIPTION
This pull request refactors the forecast that is returned as a response upon making a request to the `api/v1/forecast` endpoint into objects. This allows the response to return the objects by including the desired keys instead of deleting unneeded keys. By making this change our code is now more flexible if Darksky were to change their api responses.