### PR TITLE
Refactor get forecasts

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -3,6 +3,7 @@ var express = require('express');
 var router = express.Router();
 
 const getLatAndLongFromGoogle = require('../../../services/google_service');
+const getForecasts = require('../../../services/darksky_service');
 const Forecast = require('../../../pojos/forecast');
 
 const environment = process.env.NODE_ENV || 'development';
@@ -110,15 +111,5 @@ router.get('/', (request, response) => {
       response.status(400).json({error: 'Bad Request! Did you send an Api Key?'});
     }
 });
-
-
-async function getForecasts(location, latAndLongGoogleResults) {
-  const darkSkyApiKey = process.env.DARKSKY_API_KEY;
-  const darkSkyUrl = `https://api.darksky.net/forecast/${darkSkyApiKey}/${latAndLongGoogleResults}?exclude=minutely,flags&units=us`;
-  let response = await fetch(darkSkyUrl);
-  let forecast = await response.json();
-  let forecastForAFav = { location: location.location, current_weather: forecast.currently };
-  return forecastForAFav; // object literal - not promise object
-}
 
 module.exports = router;

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -2,6 +2,7 @@ const dotenv = require('dotenv').config();
 const Forecast = require('../../../pojos/forecast');
 const getLatAndLongFromGoogle = require('../../../services/google_service');
 
+
 var express = require('express');
 var router = express.Router();
 
@@ -30,14 +31,14 @@ router.get('/', (request, response) => {
             .then((forecastJson) => {
               // // RETURN CURRENT WEATHER INFO
               response.status(200).json(new Forecast(request.query.location, forecastJson));
-            }).catch(error => console.log(error));
+            }).catch(error => console.log(error.message));
           // END OF DARSKY API FETCHING
           });
         } else {
           response.status(401).json({error: 'Unauthorized!'});
         }
     }).catch((error) => {
-      response.status(500).json({error: error});
+      response.status(500).json({error: error.message});
     });
   } else if ((!request.body.api_key) && (request.query.location)) {
     response.status(400).json({error: 'Bad Request! Did you send in an Api Key?'});

--- a/services/darksky_service.js
+++ b/services/darksky_service.js
@@ -1,0 +1,12 @@
+const fetch = require('node-fetch');
+
+async function getForecasts(location, latAndLongGoogleResults) {
+  const darkSkyApiKey = process.env.DARKSKY_API_KEY;
+  const darkSkyUrl = `https://api.darksky.net/forecast/${darkSkyApiKey}/${latAndLongGoogleResults}?exclude=minutely,flags&units=us`;
+  let response = await fetch(darkSkyUrl);
+  let forecast = await response.json();
+  let forecastForAFav = { location: location.location, current_weather: forecast.currently };
+  return forecastForAFav; // object literal - not promise object
+}
+
+module.exports = getForecasts;


### PR DESCRIPTION
Refactor the getForecast method into a Darksky Service that can be tweaked to be reused by both endpoints that use Darksky. Right now the service returns a formatted forecast object literal for the Favorites endpoint but it could be changed to work for the Forecast endpoint too.